### PR TITLE
Fixing imx-support package URL + last version of yocto gatesgarth (3.2.4)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -3,14 +3,14 @@
 
 ## i.MX6UL XML:
 ```
-myir-i.mx6ul-5.4.3-2.0.0.xml
+myir-i.mx6ul-5.10.9-1.0.0.xml
 ```
 
-# i.MX6UL-5.4
+# i.MX6UL-5.10
 
-## repo init and get myir-i.mx6ul-5.4.3-2.0.0.xml:
+## repo init and get myir-i.mx6ul-5.10.9-1.0.0.xml:
 ```
 export REPO_URL='https://mirrors.tuna.tsinghua.edu.cn/git/git-repo/'
-repo init -u https://github.com/MYiR-Dev/myir-imx-manifest.git --no-clone-bundle --depth=1 -m myir-i.mx6ul-5.4.3-2.0.0.xml -b i.MX6UL-5.4-zeus 
+repo init -u https://github.com/MYiR-Dev/myir-imx-manifest.git --no-clone-bundle --depth=1 -m myir-i.mx6ul-5.10.9-1.0.0.xml -b i.MX6UL-5.10-gatesgarth 
 repo sync
 ```

--- a/myir-i.mx6ul-5.10.9-1.0.0.xml
+++ b/myir-i.mx6ul-5.10.9-1.0.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote name="MYiR-DEV" fetch="https://github.com/MYiR-Dev"/>
+  <remote name="MYiR-DEV" fetch="https://github.com/alvictal"/>
   <remote name="OSSystems" fetch="https://github.com/OSSystems"/>
   <remote name="QT5" fetch="https://github.com/meta-qt5"/>
   <remote name="Timesys" fetch="https://github.com/TimesysGit"/>
@@ -23,7 +23,7 @@
   <project name="meta-freescale" path="sources/meta-freescale" remote="community" revision="41d4f625c6db7a778f0f9a735c2cb48e023bc49b"/>
   <project name="meta-freescale-3rdparty" path="sources/meta-freescale-3rdparty" remote="community" revision="b85d08a55cb833bfc4e8b5034ff804286c67620e"/>
   <project name="meta-freescale-distro" path="sources/meta-freescale-distro" remote="community" revision="11be3f01962df8436c5c7b0d61cd3dbd1b872905"/>
-  <project name="meta-myir-imx" path="sources/meta-myir" remote="MYiR-DEV" revision="1428065b970ab9cfa8cc2973b1917a2e7f425964" upstream="i.MX6UL-5.10-gatesgarth">
+  <project name="meta-myir-imx" path="sources/meta-myir" remote="MYiR-DEV" revision="b934c49cabf4ded6a2d65ab6e23cf4967774baa0" upstream="i.MX6UL-5.10-gatesgarth">
     <linkfile src="tools/myir-setup-release.sh" dest="myir-setup-release.sh"/>
     <linkfile src="README" dest="README-IMXBSP"/>
   </project>

--- a/myir-i.mx6ul-5.10.9-1.0.0.xml
+++ b/myir-i.mx6ul-5.10.9-1.0.0.xml
@@ -23,7 +23,7 @@
   <project name="meta-freescale" path="sources/meta-freescale" remote="community" revision="41d4f625c6db7a778f0f9a735c2cb48e023bc49b"/>
   <project name="meta-freescale-3rdparty" path="sources/meta-freescale-3rdparty" remote="community" revision="b85d08a55cb833bfc4e8b5034ff804286c67620e"/>
   <project name="meta-freescale-distro" path="sources/meta-freescale-distro" remote="community" revision="11be3f01962df8436c5c7b0d61cd3dbd1b872905"/>
-  <project name="meta-myir-imx" path="sources/meta-myir" remote="MYiR-DEV" revision="1b78a99dee3f60077981dc91b0766d569e7bab5f" upstream="i.MX6UL-5.10-gatesgarth">
+  <project name="meta-myir-imx" path="sources/meta-myir" remote="MYiR-DEV" revision="359e5f3d9257a176e46bc4655024fa7a133d206b" upstream="i.MX6UL-5.10-gatesgarth">
     <linkfile src="tools/myir-setup-release.sh" dest="myir-setup-release.sh"/>
     <linkfile src="README" dest="README-IMXBSP"/>
   </project>

--- a/myir-i.mx6ul-5.10.9-1.0.0.xml
+++ b/myir-i.mx6ul-5.10.9-1.0.0.xml
@@ -23,7 +23,7 @@
   <project name="meta-freescale" path="sources/meta-freescale" remote="community" revision="41d4f625c6db7a778f0f9a735c2cb48e023bc49b"/>
   <project name="meta-freescale-3rdparty" path="sources/meta-freescale-3rdparty" remote="community" revision="b85d08a55cb833bfc4e8b5034ff804286c67620e"/>
   <project name="meta-freescale-distro" path="sources/meta-freescale-distro" remote="community" revision="11be3f01962df8436c5c7b0d61cd3dbd1b872905"/>
-  <project name="meta-myir-imx" path="sources/meta-myir" remote="MYiR-DEV" revision="359e5f3d9257a176e46bc4655024fa7a133d206b" upstream="i.MX6UL-5.10-gatesgarth">
+  <project name="meta-myir-imx" path="sources/meta-myir" remote="MYiR-DEV" revision="8c8cb406a19014560ce49e4324026393f8501966" upstream="i.MX6UL-5.10-gatesgarth">
     <linkfile src="tools/myir-setup-release.sh" dest="myir-setup-release.sh"/>
     <linkfile src="README" dest="README-IMXBSP"/>
   </project>

--- a/myir-i.mx6ul-5.10.9-1.0.0.xml
+++ b/myir-i.mx6ul-5.10.9-1.0.0.xml
@@ -23,7 +23,7 @@
   <project name="meta-freescale" path="sources/meta-freescale" remote="community" revision="41d4f625c6db7a778f0f9a735c2cb48e023bc49b"/>
   <project name="meta-freescale-3rdparty" path="sources/meta-freescale-3rdparty" remote="community" revision="b85d08a55cb833bfc4e8b5034ff804286c67620e"/>
   <project name="meta-freescale-distro" path="sources/meta-freescale-distro" remote="community" revision="11be3f01962df8436c5c7b0d61cd3dbd1b872905"/>
-  <project name="meta-myir-imx" path="sources/meta-myir" remote="MYiR-DEV" revision="b934c49cabf4ded6a2d65ab6e23cf4967774baa0" upstream="i.MX6UL-5.10-gatesgarth">
+  <project name="meta-myir-imx" path="sources/meta-myir" remote="MYiR-DEV" revision="1b78a99dee3f60077981dc91b0766d569e7bab5f" upstream="i.MX6UL-5.10-gatesgarth">
     <linkfile src="tools/myir-setup-release.sh" dest="myir-setup-release.sh"/>
     <linkfile src="README" dest="README-IMXBSP"/>
   </project>

--- a/myir-i.mx6ul-5.10.9-1.0.0.xml
+++ b/myir-i.mx6ul-5.10.9-1.0.0.xml
@@ -27,7 +27,7 @@
     <linkfile src="tools/myir-setup-release.sh" dest="myir-setup-release.sh"/>
     <linkfile src="README" dest="README-IMXBSP"/>
   </project>
-  <project name="meta-nxp-demo-experience" path="sources/meta-nxp-demo-experience" remote="imx-support" revision="09a7201ee64d09202b3546fef8ea34bb671cb1cd" upstream="zeus-5.4.24-2.1.0"/>
+  <project name="meta-nxp-demo-experience" path="sources/meta-nxp-demo-experience" remote="imx-support" revision="60578a5dbbfc9abc360a12e2cef7b64bfa582904" upstream="gatesgarth-5.10.9-1.0.0"/>
   <project name="meta-openembedded" path="sources/meta-openembedded" remote="oe" revision="ac4ccd2fbbb599d75ca4051911fcbaca39dbe6d7"/>
   <project name="meta-python2" path="sources/meta-python2" remote="python2" revision="c43c29e57f16af4e77441b201855321fbd546661"/>
   <project name="meta-qt5" path="sources/meta-qt5" remote="QT5" revision="8d5672cc6ca327576a814d35dfb5d59ab24043cb"/>

--- a/myir-i.mx6ul-5.10.9-1.0.0.xml
+++ b/myir-i.mx6ul-5.10.9-1.0.0.xml
@@ -33,5 +33,5 @@
   <project name="meta-qt5" path="sources/meta-qt5" remote="QT5" revision="8d5672cc6ca327576a814d35dfb5d59ab24043cb"/>
   <project name="meta-rust" path="sources/meta-rust" remote="rust" revision="53bfa324891966a2daf5d36dc13d4a43725aebed"/>
   <project name="meta-timesys" path="sources/meta-timesys" remote="Timesys" revision="00f81fbdf7fba2a09ff83d14fc3b040e9ae63b42"/>
-  <project name="poky" path="sources/poky" remote="yocto" revision="943ef2fad8428f002850e3655a3312e13d0dcb2c"/>
+  <project name="poky" path="sources/poky" remote="yocto" revision="117542f23d20d67598c9dfb1c2fcb312bac898c4"/>
 </manifest>

--- a/myir-i.mx6ul-5.10.9-1.0.0.xml
+++ b/myir-i.mx6ul-5.10.9-1.0.0.xml
@@ -1,41 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-
-  <default sync-j="8"/>
-
-  <remote fetch="git://git.yoctoproject.org" name="yocto"/>
-  <remote fetch="git://github.com/Freescale" name="community"/>
-  <remote fetch="git://github.com/openembedded" name="oe"/>
-  <remote fetch="git://github.com/OSSystems" name="OSSystems"/>
-  <remote fetch="git://github.com/meta-qt5"  name="QT5"/>
-  <remote fetch="git://github.com/TimesysGit"  name="Timesys"/>
-  <remote fetch="git://github.com/meta-rust"  name="rust"/>
-  <remote fetch="git://github.com/MYiR-Dev" name="MYiR-DEV"/>
-
-  <project remote="yocto" revision="a8f6e31bebc5a551fab1fec8d67489af80878f71" name="poky" path="sources/poky"/>
-  <project remote="community" revision="94f4f086c6014cbcfd10bda3540d19558c8bf0b0" name="meta-freescale" path="sources/meta-freescale"/>
-
-  <project remote="oe" revision="bb65c27a772723dfe2c15b5e1b27bcc1a1ed884c" name="meta-openembedded" path="sources/meta-openembedded"/>
-
-  <project remote="community" revision="6e0d5d90fa8dd0c7abee04bbe103bc6a5ff8a8f7" name="fsl-community-bsp-base" path="sources/base">
-    <linkfile dest="README" src="README"/>
-    <linkfile dest="setup-environment" src="setup-environment"/>
+  <remote name="MYiR-DEV" fetch="git://github.com/MYiR-Dev"/>
+  <remote name="OSSystems" fetch="https://github.com/OSSystems"/>
+  <remote name="QT5" fetch="https://github.com/meta-qt5"/>
+  <remote name="Timesys" fetch="https://github.com/TimesysGit"/>
+  <remote name="clang" fetch="https://github.com/kraj"/>
+  <remote name="community" fetch="https://github.com/Freescale"/>
+  <remote name="imx-support" fetch="https://source.codeaurora.org/external/imxsupport"/>
+  <remote name="oe" fetch="https://github.com/openembedded"/>
+  <remote name="python2" fetch="https://git.openembedded.org"/>
+  <remote name="rust" fetch="https://github.com/meta-rust"/>
+  <remote name="yocto" fetch="https://git.yoctoproject.org/git"/>
+  
+  <default sync-j="2"/>
+  
+  <project name="fsl-community-bsp-base" path="sources/base" remote="community" revision="9d7b7caeba7ebd6c315bf99950e4501662ddeb80">
+    <linkfile src="README" dest="README"/>
+    <linkfile src="setup-environment" dest="setup-environment"/>
   </project>
-
-  <project remote="community" revision="aea3771baa77e74762358ceb673d407e36637e5f" name="meta-freescale-3rdparty" path="sources/meta-freescale-3rdparty"/>
-  <project remote="community" revision="ca27d12e4964d1336e662bcc60184bbff526c857" name="meta-freescale-distro" path="sources/meta-freescale-distro"/>
-
-  <project remote="OSSystems" revision="5f365ef0f842ba4651efe88787cf9c63bc8b6cb3" name="meta-browser" path="sources/meta-browser" />
-  <project remote="rust" revision="d8d77be1292064a02adcb5e72e293604b704f69b" name="meta-rust" path="sources/meta-rust" />
-  <project remote="QT5" revision="a582fd4c810529e9af0c81700407b1955d1391d2" name="meta-qt5" path="sources/meta-qt5" />
-
-  <project remote="Timesys" revision="ef776166d7a4f7c8677137adbfd6adee6a0e2389" name="meta-timesys" path="sources/meta-timesys" />
-
-  <project remote="MYiR-DEV" revision="1428065b970ab9cfa8cc2973b1917a2e7f425964" name="meta-myir-imx" path="sources/meta-myir" upstream=" i.MX6UL-5.10-gatesgarth" >
-     <linkfile src="tools/myir-setup-release.sh" dest="myir-setup-release.sh"/>
-     <linkfile src="README" dest="README-IMXBSP"/>
+  <project name="meta-browser" path="sources/meta-browser" remote="OSSystems" revision="ee3be3b5986a4aa0e73df2204a625ae1fe5df37e"/>
+  <project name="meta-clang" path="sources/meta-clang" remote="clang" revision="61faae011fb95712064f2c58abe6293f0daeeab5"/>
+  <project name="meta-freescale" path="sources/meta-freescale" remote="community" revision="41d4f625c6db7a778f0f9a735c2cb48e023bc49b"/>
+  <project name="meta-freescale-3rdparty" path="sources/meta-freescale-3rdparty" remote="community" revision="b85d08a55cb833bfc4e8b5034ff804286c67620e"/>
+  <project name="meta-freescale-distro" path="sources/meta-freescale-distro" remote="community" revision="11be3f01962df8436c5c7b0d61cd3dbd1b872905"/>
+  <project name="meta-myir-imx" path="sources/meta-myir" remote="MYiR-DEV" revision="1428065b970ab9cfa8cc2973b1917a2e7f425964" upstream="i.MX6UL-5.10-gatesgarth">
+    <linkfile src="tools/myir-setup-release.sh" dest="myir-setup-release.sh"/>
+    <linkfile src="README" dest="README-IMXBSP"/>
   </project>
-
-
-
+  <project name="meta-nxp-demo-experience" path="sources/meta-nxp-demo-experience" remote="imx-support" revision="c7263d9f3cc7bbf44e7164ffeda494cf283d3dec" upstream="zeus-5.4.24-2.1.0"/>
+  <project name="meta-openembedded" path="sources/meta-openembedded" remote="oe" revision="ac4ccd2fbbb599d75ca4051911fcbaca39dbe6d7"/>
+  <project name="meta-python2" path="sources/meta-python2" remote="python2" revision="c43c29e57f16af4e77441b201855321fbd546661"/>
+  <project name="meta-qt5" path="sources/meta-qt5" remote="QT5" revision="8d5672cc6ca327576a814d35dfb5d59ab24043cb"/>
+  <project name="meta-rust" path="sources/meta-rust" remote="rust" revision="53bfa324891966a2daf5d36dc13d4a43725aebed"/>
+  <project name="meta-timesys" path="sources/meta-timesys" remote="Timesys" revision="00f81fbdf7fba2a09ff83d14fc3b040e9ae63b42"/>
+  <project name="poky" path="sources/poky" remote="yocto" revision="943ef2fad8428f002850e3655a3312e13d0dcb2c"/>
 </manifest>

--- a/myir-i.mx6ul-5.10.9-1.0.0.xml
+++ b/myir-i.mx6ul-5.10.9-1.0.0.xml
@@ -23,7 +23,7 @@
   <project name="meta-freescale" path="sources/meta-freescale" remote="community" revision="41d4f625c6db7a778f0f9a735c2cb48e023bc49b"/>
   <project name="meta-freescale-3rdparty" path="sources/meta-freescale-3rdparty" remote="community" revision="b85d08a55cb833bfc4e8b5034ff804286c67620e"/>
   <project name="meta-freescale-distro" path="sources/meta-freescale-distro" remote="community" revision="11be3f01962df8436c5c7b0d61cd3dbd1b872905"/>
-  <project name="meta-myir-imx" path="sources/meta-myir" remote="MYiR-DEV" revision="8c8cb406a19014560ce49e4324026393f8501966" upstream="i.MX6UL-5.10-gatesgarth">
+  <project name="meta-myir-imx" path="sources/meta-myir" remote="MYiR-DEV" revision="ce59bcc9ff916f2bd2c50e4b60b37e3c28034d8b" upstream="i.MX6UL-5.10-gatesgarth">
     <linkfile src="tools/myir-setup-release.sh" dest="myir-setup-release.sh"/>
     <linkfile src="README" dest="README-IMXBSP"/>
   </project>

--- a/myir-i.mx6ul-5.10.9-1.0.0.xml
+++ b/myir-i.mx6ul-5.10.9-1.0.0.xml
@@ -6,7 +6,7 @@
   <remote name="Timesys" fetch="https://github.com/TimesysGit"/>
   <remote name="clang" fetch="https://github.com/kraj"/>
   <remote name="community" fetch="https://github.com/Freescale"/>
-  <remote name="imx-support" fetch="https://source.codeaurora.org/external/imxsupport"/>
+  <remote name="imx-support" fetch="https://github.com/nxp-imx-support"/>
   <remote name="oe" fetch="https://github.com/openembedded"/>
   <remote name="python2" fetch="https://git.openembedded.org"/>
   <remote name="rust" fetch="https://github.com/meta-rust"/>
@@ -27,7 +27,7 @@
     <linkfile src="tools/myir-setup-release.sh" dest="myir-setup-release.sh"/>
     <linkfile src="README" dest="README-IMXBSP"/>
   </project>
-  <project name="meta-nxp-demo-experience" path="sources/meta-nxp-demo-experience" remote="imx-support" revision="c7263d9f3cc7bbf44e7164ffeda494cf283d3dec" upstream="zeus-5.4.24-2.1.0"/>
+  <project name="meta-nxp-demo-experience" path="sources/meta-nxp-demo-experience" remote="imx-support" revision="09a7201ee64d09202b3546fef8ea34bb671cb1cd" upstream="zeus-5.4.24-2.1.0"/>
   <project name="meta-openembedded" path="sources/meta-openembedded" remote="oe" revision="ac4ccd2fbbb599d75ca4051911fcbaca39dbe6d7"/>
   <project name="meta-python2" path="sources/meta-python2" remote="python2" revision="c43c29e57f16af4e77441b201855321fbd546661"/>
   <project name="meta-qt5" path="sources/meta-qt5" remote="QT5" revision="8d5672cc6ca327576a814d35dfb5d59ab24043cb"/>

--- a/myir-i.mx6ul-5.10.9-1.0.0.xml
+++ b/myir-i.mx6ul-5.10.9-1.0.0.xml
@@ -31,7 +31,7 @@
 
   <project remote="Timesys" revision="ef776166d7a4f7c8677137adbfd6adee6a0e2389" name="meta-timesys" path="sources/meta-timesys" />
 
-  <project remote="MYiR-DEV" revision="f4ef7654ca0bb3f7464c193a8fe4675e39f49242" name="meta-myir-imx" path="sources/meta-myir" upstream="i.MX6UL-5.4-zeus" >
+  <project remote="MYiR-DEV" revision="1428065b970ab9cfa8cc2973b1917a2e7f425964" name="meta-myir-imx" path="sources/meta-myir" upstream=" i.MX6UL-5.10-gatesgarth" >
      <linkfile src="tools/myir-setup-release.sh" dest="myir-setup-release.sh"/>
      <linkfile src="README" dest="README-IMXBSP"/>
   </project>

--- a/myir-i.mx6ul-5.10.9-1.0.0.xml
+++ b/myir-i.mx6ul-5.10.9-1.0.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote name="MYiR-DEV" fetch="git://github.com/MYiR-Dev"/>
+  <remote name="MYiR-DEV" fetch="https://github.com/MYiR-Dev"/>
   <remote name="OSSystems" fetch="https://github.com/OSSystems"/>
   <remote name="QT5" fetch="https://github.com/meta-qt5"/>
   <remote name="Timesys" fetch="https://github.com/TimesysGit"/>

--- a/myir-imx6ul-5.x-y.xml
+++ b/myir-imx6ul-5.x-y.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+    <remote name="yocto" fetch="https://git.yoctoproject.org/"/>
+    <remote name="freescale" fetch="https://github.com/Freescale"/>
+    <remote name="oe" fetch="https://github.com/openembedded"/>
+    <remote name="rust" fetch="https://github.com/meta-rust"/>
+    <remote name="QT5" fetch="https://github.com/meta-qt5"/>
+    <remote name="OSSystems" fetch="https://github.com/OSSystems"/>
+    <remote name="MYiR-DEV" fetch="https://github.com/alvictal"/>
+    
+    
+    <default sync-j="2"/>
+
+    <project name="bitbake.git" path="layers/openembedded-core/bitbake" remote="oe" revision="2.0"/>
+    <project name="meta-openembedded.git" path="layers/meta-openembedded" remote="oe" revision="kirkstone"/>
+    <project name="meta-yocto" path="layers/meta-yocto" remote="yocto" revision="kirkstone"/>
+    <project name="openembedded-core.git" path="layers/openembedded-core" remote="oe" revision="kirkstone"/>
+    <project name="meta-freescale-3rdparty.git" path="layers/meta-freescale-3rdparty" remote="freescale" revision="kirkstone"/>
+    <project name="meta-freescale-distro.git" path="layers/meta-freescale-distro" remote="freescale" revision="kirkstone"/>
+    <project name="meta-freescale.git" path="layers/meta-freescale" remote="freescale" revision="kirkstone"/>
+    <project name="meta-qt5" path="layers/meta-qt5" remote="QT5" revision="644ebf220245bdc06e7696ccc90acc97a0dd2566" upstream="kirkstone"/>
+    <project name="meta-security" path="layers/meta-security" remote="yocto" revision="353078bc06c8b471736daab6ed193e30d533d1f1" upstream="kirkstone"/>
+    <project name="meta-browser" path="layers/meta-browser" remote="OSSystems" upstream="kirkstone"/>
+    
+    <project name="fsl-community-bsp-base" path="layers/base" remote="freescale" revision="60f79f7af60537146298560079ae603260f0bd14" upstream="kirkstone">
+        <linkfile src="README" dest="README"/>
+        <linkfile src="setup-environment" dest="setup-environment"/>
+    </project>
+
+    <project name="meta-myir-imx" path="layers/meta-myir" remote="MYiR-DEV" upstream="main">
+        <linkfile src="tools/myir-setup-release.sh" dest="myir-setup-release.sh"/>
+        <linkfile src="README" dest="README-IMXBSP"/>
+    </project>
+
+   <!-- 
+    <remote name="Timesys" fetch="https://github.com/TimesysGit"/>
+    <remote name="clang" fetch="https://github.com/kraj"/>
+    <remote name="python2" fetch="https://git.openembedded.org"/>
+    
+    <project name="meta-freescale" path="layers/meta-freescale" remote="freescale" revision="fb17bfb8edcc9560bc1beb966a68f1f4c08ecfb3" upstream="kirkstone" />
+    <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" remote="freescale" revision="9e94b64bdfebcf7bfdf2af6447cec866a4efa814" upstream="kirkstone" />
+    <project name="meta-freescale-distro" path="layers/meta-freescale-distro" remote="freescale" revision="d5bbb487b2816dfc74984a78b67f7361ce404253" upstream="kirkstone"/>
+    <project name="meta-openembedded" path="layers/meta-openembedded" remote="oe" revision="0560b848996a0feb410a8cd8ca07c60fe2f3b5bc" upstream="kirkstone"/> 
+    
+
+    <project name="meta-clang" path="sources/meta-clang" remote="clang" revision="61faae011fb95712064f2c58abe6293f0daeeab5"/>
+
+    <project name="meta-python2" path="sources/meta-python2" remote="python2" revision="c43c29e57f16af4e77441b201855321fbd546661"/>
+    <project name="meta-qt5" path="sources/meta-qt5" remote="QT5" revision="8d5672cc6ca327576a814d35dfb5d59ab24043cb"/>
+    <project name="meta-rust" path="sources/meta-rust" remote="rust" revision="53bfa324891966a2daf5d36dc13d4a43725aebed"/>
+    <project name="meta-timesys" path="sources/meta-timesys" remote="Timesys" revision="00f81fbdf7fba2a09ff83d14fc3b040e9ae63b42"/>-->
+    
+</manifest>


### PR DESCRIPTION
Some issues occur when syncing the repository because the URL source.codeaurora.org does not exist. Change the URL to use the current "nxp-imx-support" git base. Also, adding the last revision for gatesgarth