### PR TITLE
[imx8] fixed imx-support git source

### DIFF
--- a/myir-i.mx8m-5.10.9-1.0.0.xml
+++ b/myir-i.mx8m-5.10.9-1.0.0.xml
@@ -18,20 +18,20 @@
     <linkfile src="README" dest="README"/>
     <linkfile src="setup-environment" dest="setup-environment"/>
   </project>
-  <project name="meta-browser" path="sources/meta-browser" remote="OSSystems" revision="ee3be3b5986a4aa0e73df2204a625ae1fe5df37e"/>
-  <project name="meta-clang" path="sources/meta-clang" remote="clang" revision="61faae011fb95712064f2c58abe6293f0daeeab5"/>
+  <project name="meta-browser" path="sources/meta-browser" remote="OSSystems" revision="ee3be3b5986a4aa0e73df2204a625ae1fe5df37e" clone-depth="1"/>
+  <project name="meta-clang" path="sources/meta-clang" remote="clang" revision="61faae011fb95712064f2c58abe6293f0daeeab5" clone-depth="1"/>
   <project name="meta-freescale" path="sources/meta-freescale" remote="community" revision="41d4f625c6db7a778f0f9a735c2cb48e023bc49b"/>
-  <project name="meta-freescale-3rdparty" path="sources/meta-freescale-3rdparty" remote="community" revision="b85d08a55cb833bfc4e8b5034ff804286c67620e"/>
-  <project name="meta-freescale-distro" path="sources/meta-freescale-distro" remote="community" revision="11be3f01962df8436c5c7b0d61cd3dbd1b872905"/>
-  <project name="meta-myir-imx" path="sources/meta-myir" remote="MYiR-DEV" revision="16f45685d27490a14a4f46a0f55162ed196e2f92" upstream="i.MX8M-5.10-gatesgarth">
-    <linkfile src="tools/myir-setup-release.sh" dest="myir-setup-release.sh"/>
+  <project name="meta-freescale-3rdparty" path="sources/meta-freescale-3rdparty" remote="community" revision="b85d08a55cb833bfc4e8b5034ff804286c67620e" clone-depth="1"/>
+  <project name="meta-freescale-distro" path="sources/meta-freescale-distro" remote="community" revision="11be3f01962df8436c5c7b0d61cd3dbd1b872905" clone-depth="1"/>
+  <project name="meta-myir-imx" path="sources/meta-myir" remote="MYiR-DEV" revision="16f45685d27490a14a4f46a0f55162ed196e2f92" upstream="i.MX8M-5.10-gatesgarth" clone-depth="1">
+    <linkfile src="tools/myir-setup-release.sh" dest="myir-setup-release.sh" clone-depth="1"/>
     <linkfile src="README" dest="README-IMXBSP"/>
   </project>
-  <project name="meta-nxp-demo-experience" path="sources/meta-nxp-demo-experience" remote="imx-support" revision="03904c493469907a2829cf29df7ab060f9c664a6" upstream="zeus-5.4.24-2.1.0"/>
-  <project name="meta-openembedded" path="sources/meta-openembedded" remote="oe" revision="ac4ccd2fbbb599d75ca4051911fcbaca39dbe6d7"/>
-  <project name="meta-python2" path="sources/meta-python2" remote="python2" revision="c43c29e57f16af4e77441b201855321fbd546661"/>
-  <project name="meta-qt5" path="sources/meta-qt5" remote="QT5" revision="8d5672cc6ca327576a814d35dfb5d59ab24043cb"/>
-  <project name="meta-rust" path="sources/meta-rust" remote="rust" revision="53bfa324891966a2daf5d36dc13d4a43725aebed"/>
-  <project name="meta-timesys" path="sources/meta-timesys" remote="Timesys" revision="00f81fbdf7fba2a09ff83d14fc3b040e9ae63b42"/>
-  <project name="poky" path="sources/poky" remote="yocto" revision="943ef2fad8428f002850e3655a3312e13d0dcb2c"/>
+  <project name="meta-nxp-demo-experience" path="sources/meta-nxp-demo-experience" remote="imx-support" revision="03904c493469907a2829cf29df7ab060f9c664a6" upstream="zeus-5.4.24-2.1.0" clone-depth="1"/>
+  <project name="meta-openembedded" path="sources/meta-openembedded" remote="oe" revision="ac4ccd2fbbb599d75ca4051911fcbaca39dbe6d7" clone-depth="1"/>
+  <project name="meta-python2" path="sources/meta-python2" remote="python2" revision="c43c29e57f16af4e77441b201855321fbd546661" clone-depth="1"/>
+  <project name="meta-qt5" path="sources/meta-qt5" remote="QT5" revision="8d5672cc6ca327576a814d35dfb5d59ab24043cb" clone-depth="1"/>
+  <project name="meta-rust" path="sources/meta-rust" remote="rust" revision="53bfa324891966a2daf5d36dc13d4a43725aebed" clone-depth="1"/>
+  <project name="meta-timesys" path="sources/meta-timesys" remote="Timesys" revision="00f81fbdf7fba2a09ff83d14fc3b040e9ae63b42" clone-depth="1"/>
+  <project name="poky" path="sources/poky" remote="yocto" revision="943ef2fad8428f002850e3655a3312e13d0dcb2c" clone-depth="1"/>
 </manifest>

--- a/myir-i.mx8m-5.10.9-1.0.0.xml
+++ b/myir-i.mx8m-5.10.9-1.0.0.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote name="MYiR-DEV" fetch="git://github.com/MYiR-Dev"/>
+  <remote name="MYiR-DEV" fetch="https://github.com/MYiR-Dev"/>
   <remote name="OSSystems" fetch="https://github.com/OSSystems"/>
   <remote name="QT5" fetch="https://github.com/meta-qt5"/>
   <remote name="Timesys" fetch="https://github.com/TimesysGit"/>
   <remote name="clang" fetch="https://github.com/kraj"/>
   <remote name="community" fetch="https://github.com/Freescale"/>
-  <remote name="imx-support" fetch="https://source.codeaurora.org/external/imxsupport"/>
+  <remote name="imx-support" fetch="https://github.com/nxp-imx-support"/>
   <remote name="oe" fetch="https://github.com/openembedded"/>
   <remote name="python2" fetch="https://git.openembedded.org"/>
   <remote name="rust" fetch="https://github.com/meta-rust"/>
   <remote name="yocto" fetch="https://git.yoctoproject.org/git"/>
-  
+
   <default sync-j="2"/>
-  
+
   <project name="fsl-community-bsp-base" path="sources/base" remote="community" revision="9d7b7caeba7ebd6c315bf99950e4501662ddeb80">
     <linkfile src="README" dest="README"/>
     <linkfile src="setup-environment" dest="setup-environment"/>
@@ -27,7 +27,7 @@
     <linkfile src="tools/myir-setup-release.sh" dest="myir-setup-release.sh"/>
     <linkfile src="README" dest="README-IMXBSP"/>
   </project>
-  <project name="meta-nxp-demo-experience" path="sources/meta-nxp-demo-experience" remote="imx-support" revision="c7263d9f3cc7bbf44e7164ffeda494cf283d3dec" upstream="zeus-5.4.24-2.1.0"/>
+  <project name="meta-nxp-demo-experience" path="sources/meta-nxp-demo-experience" remote="imx-support" revision="03904c493469907a2829cf29df7ab060f9c664a6" upstream="zeus-5.4.24-2.1.0"/>
   <project name="meta-openembedded" path="sources/meta-openembedded" remote="oe" revision="ac4ccd2fbbb599d75ca4051911fcbaca39dbe6d7"/>
   <project name="meta-python2" path="sources/meta-python2" remote="python2" revision="c43c29e57f16af4e77441b201855321fbd546661"/>
   <project name="meta-qt5" path="sources/meta-qt5" remote="QT5" revision="8d5672cc6ca327576a814d35dfb5d59ab24043cb"/>


### PR DESCRIPTION
source.codeaurora.org has been dropped by NXP,
and immigrated to NXP's github.