### PR TITLE
Update myir-i.mx93-6.1.55-2.2.0.xml

### DIFF
--- a/myir-i.mx93-6.1.55-2.2.0.xml
+++ b/myir-i.mx93-6.1.55-2.2.0.xml
@@ -12,7 +12,7 @@
   <remote name="qt"          fetch="https://code.qt.io/yocto"/>
   <remote name="timesys"     fetch="https://github.com/TimesysGit"/>
 
-  <remote name="MYiR-Dev"     fetch="https://github.com/MYiR-Dev"/>
+  <remote name="MYiR-DEV"     fetch="https://github.com/MYiR-Dev"/>
   <remote name="imx-support" fetch="https://github.com/nxp-imx-support"/>
 
   <project name="poky" remote="yp" path="sources/poky" revision="a57506c46d92bf0767060102d2139be06d46f575" upstream="mickledore"/>


### PR DESCRIPTION
textual error in manifest

error without fix
```fatal: manifest 'myir-i.mx93-6.1.55-2.2.0.xml' not available
fatal: remote MYiR-DEV not defined in /home/yocto/myd-lmx9x-yocto/myd-lmx9x-yocto/.repo/manifests/myir-i.mx93-6.1.55-2.2.0.xml
================================================================================
Repo command failed: UpdateManifestError
        Unable to sync manifest myir-i.mx93-6.1.55-2.2.0.xml```